### PR TITLE
fixed bug in chooseAccount behavior due to urlscheme format

### DIFF
--- a/react-web-app/src/App.js
+++ b/react-web-app/src/App.js
@@ -29,8 +29,8 @@ function App() {
     // check query params for mobile
     if (params.get("integrationContext") && params.get("urlScheme")) {
 			if (!data.metadata) data.metadata = {};
-      data.metadata.urlScheme = params.get("urlScheme");
-      data.metadata.integrationContext = "InAppBrowser";
+      data.metadata.urlScheme = `${params.get("urlScheme")}://`;
+      data.metadata.integrationContext = params.get("integrationContext");
     }
     return data;
   };


### PR DESCRIPTION
Updated the way the react app dynamically sets metadata. 
This fixes a bug where after choosing an account in an OAuth bank, the Lightbox throws an error
In addition, previously the `integrationContext` type was hardcoded based on the presence of that parameter in the url, this was made dynamic for a cleaner implementation and to avoid confusion.